### PR TITLE
Autoload PostCSS config

### DIFF
--- a/packages/postcss/index.js
+++ b/packages/postcss/index.js
@@ -1,20 +1,54 @@
 'use strict';
 
-const extn = require('path').extname;
+const res = require('path').resolve;
 const postcss = require('postcss');
 
-module.exports = function (task) {
+const base = { plugins:[], options:{} };
+const isObject = any => Boolean(any) && (any.constructor === Object);
+const isNullType = any => any == null;
+
+module.exports = function (task, utils) {
+	const rootPath = str => res(task.root, str);
+	const findRoot = str => utils.find(rootPath(str));
+	const readRoot = str => utils.read(rootPath(str), 'utf8');
 	const setError = msg => task.emit('plugin_error', { plugin:'@taskr/postcss', error:msg });
 
-	task.plugin('postcss', {}, function * (file, opts) {
-		opts = Object.assign({ plugins:[], options:{} }, opts);
+	task.plugin('postcss', { every:false }, function * (files, opts) {
+		let config;
 
-		try {
-			const ctx = postcss(opts.plugins);
-			const out = yield ctx.process(file.data.toString(), opts);
-			file.data = Buffer.from(out.css); // write new data
-		} catch (err) {
-			return setError(err.message);
+		if (isObject(opts)) {
+			config = opts;
+		} else if (isNullType(opts)) {
+			// look for `.postcssrc` or "postcss" key in `package.json`
+			config = JSON.parse(yield readRoot('.postcssrc')) || JSON.parse(yield readRoot('package.json')).postcss;
+			if (isNullType(config)) {
+				// look for `postcss.config.js` or `.postcssrc.js`
+				const fileConfig = (yield findRoot('postcss.config.js')) || (yield findRoot('.postcssrc.js'));
+				if (!isNullType(fileConfig)) {
+					// pass thru `require` because always `module.exports`
+					config = require(fileConfig);
+					// handle function exports, pass default value
+					(typeof config === 'function') && (config = config(base));
+				}
+			}
 		}
-	})
+
+		config = config || {};
+
+		if (!isObject(config)) {
+			return setError(`Invalid PostCSS config! An object is required; recevied: ${typeof config}`);
+		}
+
+		opts = Object.assign({}, base, config);
+
+		for (const file of files) {
+			try {
+				const ctx = postcss(opts.plugins);
+				const out = yield ctx.process(file.data.toString(), opts);
+				file.data = Buffer.from(out.css); // write new data
+			} catch (err) {
+				return setError(err.message);
+			}
+		}
+	});
 }

--- a/packages/postcss/index.js
+++ b/packages/postcss/index.js
@@ -5,7 +5,7 @@ const postcss = require('postcss');
 
 const base = { plugins:[], options:{} };
 const isObject = any => Boolean(any) && (any.constructor === Object);
-const isNullType = any => any == null;
+const isEmptyObj = any => isObject(any) && Object.keys(any).length === 0;
 
 module.exports = function (task, utils) {
 	const rootPath = str => res(task.root, str);
@@ -16,24 +16,45 @@ module.exports = function (task, utils) {
 	task.plugin('postcss', { every:false }, function * (files, opts) {
 		let config;
 
-		if (isObject(opts)) {
-			config = opts;
-		} else if (isNullType(opts)) {
+		if (isEmptyObj(opts)) {
+			console.log('WAS NULL OPTS', task.root);
 			// look for `.postcssrc` or "postcss" key in `package.json`
-			config = JSON.parse(yield readRoot('.postcssrc')) || JSON.parse(yield readRoot('package.json')).postcss;
-			if (isNullType(config)) {
+			config = JSON.parse(yield readRoot('.postcssrc')) || JSON.parse(yield readRoot('package.json') || '{}').postcss;
+			// these files will only be JSON objects (only)
+			if (isObject(config)) {
+				// reconstruct "plugins"
+				let fn, key, plugins = [];
+				const old = config.plugins || {};
+				for (key in old) {
+					console.log(`this is key!!! ${key}`);
+					try {
+						console.log(key, old[key]);
+						fn = require(key)(old[key] || {});
+						plugins.push(fn);
+					} catch (err) {
+						console.log('errored', err);
+						return setError(`Loading PostCSS plugin (${key}) failed with: ${err.message}`);
+					}
+				}
+				// update config
+				config.plugins = plugins;
+			} else {
 				// look for `postcss.config.js` or `.postcssrc.js`
 				const fileConfig = (yield findRoot('postcss.config.js')) || (yield findRoot('.postcssrc.js'));
-				if (!isNullType(fileConfig)) {
+				if (fileConfig !== null) {
 					// pass thru `require` because always `module.exports`
 					config = require(fileConfig);
 					// handle function exports, pass default value
 					(typeof config === 'function') && (config = config(base));
 				}
 			}
+		} else {
+			config = opts; // wasnt empty
 		}
 
 		config = config || {};
+
+		console.log('FINAL CONFIG', config);
 
 		if (!isObject(config)) {
 			return setError(`Invalid PostCSS config! An object is required; recevied: ${typeof config}`);

--- a/packages/postcss/index.js
+++ b/packages/postcss/index.js
@@ -6,6 +6,7 @@ const postcss = require('postcss');
 const base = { plugins:[], options:{} };
 const filenames = ['.postcssrc', '.postcssrc.js', 'postcss.config.js', 'package.json'];
 
+const isString = any => typeof any === 'string';
 const isObject = any => Boolean(any) && (any.constructor === Object);
 const isEmptyObj = any => isObject(any) && Object.keys(any).length === 0;
 
@@ -65,6 +66,14 @@ module.exports = function (task, utils) {
 						}
 						config.plugins = plugins; // update config
 					}
+
+					// reconstruct options
+					if (config.options !== void 0) {
+						const co = config.options;
+						config.options.parser = isString(co.parser) ? require(co.parser) : co.parser;
+						config.options.syntax = isString(co.syntax) ? require(co.syntax) : co.syntax;
+						config.options.stringifier = isString(co.stringifier) ? require(co.stringifier) : co.stringifier;
+						(co.plugins !== void 0) && (delete config.options.plugins);
 					}
 				}
 			}

--- a/packages/postcss/index.js
+++ b/packages/postcss/index.js
@@ -4,57 +4,58 @@ const res = require('path').resolve;
 const postcss = require('postcss');
 
 const base = { plugins:[], options:{} };
+const filenames = ['.postcssrc', '.postcssrc.js', 'postcss.config.js', 'package.json'];
+
 const isObject = any => Boolean(any) && (any.constructor === Object);
 const isEmptyObj = any => isObject(any) && Object.keys(any).length === 0;
 
 module.exports = function (task, utils) {
-	const rootPath = str => res(task.root, str);
-	const findRoot = str => utils.find(rootPath(str));
-	const readRoot = str => utils.read(rootPath(str), 'utf8');
+	const rootDir = str => res(task.root, str);
 	const setError = msg => task.emit('plugin_error', { plugin:'@taskr/postcss', error:msg });
+	const getConfig = arr => Promise.all(arr.map(utils.find)).then(res => res.filter(Boolean)).then(res => res[0]);
 
 	task.plugin('postcss', { every:false }, function * (files, opts) {
 		let config;
 
 		if (isEmptyObj(opts)) {
-			console.log('WAS NULL OPTS', task.root);
-			// look for `.postcssrc` or "postcss" key in `package.json`
-			config = JSON.parse(yield readRoot('.postcssrc')) || JSON.parse(yield readRoot('package.json') || '{}').postcss;
-			// these files will only be JSON objects (only)
-			if (isObject(config)) {
-				// reconstruct "plugins"
-				let fn, key, plugins = [];
-				const old = config.plugins || {};
-				for (key in old) {
-					console.log(`this is key!!! ${key}`);
+			// autoload a file
+			const fileConfig = yield getConfig(filenames.map(rootDir));
+			// process if found one!
+			if (fileConfig !== void 0) {
+				try {
+					config = require(fileConfig);
+				} catch (err) {
 					try {
-						console.log(key, old[key]);
-						fn = require(key)(old[key] || {});
-						plugins.push(fn);
-					} catch (err) {
-						console.log('errored', err);
-						return setError(`Loading PostCSS plugin (${key}) failed with: ${err.message}`);
+						config = JSON.parse(yield utils.read(fileConfig, 'utf8')); // .rc file
+					} catch (_) {
+						return setError(err.message);
 					}
 				}
-				// update config
-				config.plugins = plugins;
-			} else {
-				// look for `postcss.config.js` or `.postcssrc.js`
-				const fileConfig = (yield findRoot('postcss.config.js')) || (yield findRoot('.postcssrc.js'));
-				if (fileConfig !== null) {
-					// pass thru `require` because always `module.exports`
-					config = require(fileConfig);
-					// handle function exports, pass default value
-					(typeof config === 'function') && (config = config(base));
+				// handle config types
+				if (typeof config === 'function') {
+					config = config(base); // send default values
+				} else if (isObject(config)) {
+					// grab "postcss" key (package.json)
+					config = config.postcss || config;
+					// reconstruct plugins?
+					if (isObject(config.plugins)) {
+						let k, plugins = [];
+						const old = config.plugins || {};
+						for (k in old) {
+							try {
+								plugins.push(require(k)(old[k]));
+							} catch (err) {
+								return setError(`Loading PostCSS plugin (${k}) failed with: ${err.message}`);
+							}
+						}
+						// update config
+						config.plugins = plugins;
+					}
 				}
 			}
-		} else {
-			config = opts; // wasnt empty
 		}
 
-		config = config || {};
-
-		console.log('FINAL CONFIG', config);
+		config = config || opts;
 
 		if (!isObject(config)) {
 			return setError(`Invalid PostCSS config! An object is required; recevied: ${typeof config}`);

--- a/packages/postcss/index.js
+++ b/packages/postcss/index.js
@@ -4,6 +4,8 @@ const extn = require('path').extname;
 const postcss = require('postcss');
 
 module.exports = function (task) {
+	const setError = msg => task.emit('plugin_error', { plugin:'@taskr/postcss', error:msg });
+
 	task.plugin('postcss', {}, function * (file, opts) {
 		opts = Object.assign({ plugins:[], options:{} }, opts);
 
@@ -11,11 +13,8 @@ module.exports = function (task) {
 			const ctx = postcss(opts.plugins);
 			const out = yield ctx.process(file.data.toString(), opts);
 			file.data = Buffer.from(out.css); // write new data
-		} catch (error) {
-			task.emit('plugin_error', {
-				plugin: '@taskr/postcss',
-				error: error.message
-			});
+		} catch (err) {
+			return setError(err.message);
 		}
 	})
 }

--- a/packages/postcss/readme.md
+++ b/packages/postcss/readme.md
@@ -8,31 +8,74 @@
 $ npm install --save-dev @taskr/postcss
 ```
 
-## Usage
-
-The paths within `task.source()` should always point to files that you want transformed into `.css` files.
-
-```js
-exports.test = function * (task) {
-  yield task.source('src/**/*.scss').postcss({
-    plugins: [
-      require('precss'),
-      require('autoprefixer')
-    ],
-    options: {
-      parser: require('postcss-scss')
-    }
-  }).target('dist');
-}
-```
-
 ## API
 
-### .postcss(options)
+### .postcss([options])
 
 Check out PostCSS's [Options](https://github.com/postcss/postcss#options) documentation to see the available options.
 
 > **Note:** There should be no need to set `options.to` and `options.from`.
+
+If you would like to [autoload external PostCSS config](#autoloaded-options), you must not define any `options` directly.
+
+
+## Usage
+
+#### Embedded Options
+
+> Declare your PostCSS options directly within your `taskfile.js`:
+
+```js
+exports.styles = function * (task) {
+  yield task.source('src/**/*.scss').postcss({
+    plugins: [
+      require('precss'),
+      require('autoprefixer')({
+        browsers: ['last 2 versions']
+      })
+    ],
+    options: {
+      parser: require('postcss-scss')
+    }
+  }).target('dist/css');
+}
+```
+
+#### Autoloaded Options
+
+> Automatically detect & connect to existing PostCSS configurations
+
+If no [`options`](#api) were defined, `@taskr/postcss` will look for existing `.postcssrc`, `postcss.config.js`, and `.postcssrc.js` root-directory files. Similarly, it will honor a `"postcss"` key within your `package.json` file.
+
+* `.postcssrc` -- must be JSON; see [example](/test/fixtures/sub1/.postcssrc)
+* `.postcssrc.js` -- can be JSON or `module.exports` a Function or Object; see [example](/test/fixtures/sub4/.postcssrc.js)
+* `postcss.config.js` -- can be JSON or `module.exports` a Function or Object; see [example](/test/fixtures/sub3/postcss.config.js)
+* `package.json` -- must use `"postcss"` key & must be JSON; see [example](/test/fixtures/sub2/package.json)
+
+> **Important:** If you take this route, you only need _one_ of the files mentioned!
+
+```js
+// taskfile.js
+exports.styles = function * (task) {
+  yield task.source('src/**/*.scss').postcss().target('dist/css');
+}
+```
+
+```js
+// .postcssrc
+{
+  "plugins": {
+    "precss": {},
+    "autoprefixer": {
+      "browsers": ["last 2 versions"]
+    }
+  },
+  "options": {
+    "parser": "postcss-scss"
+  }
+}
+```
+
 
 ## Support
 

--- a/packages/postcss/test/fixtures/sub1/.postcssrc
+++ b/packages/postcss/test/fixtures/sub1/.postcssrc
@@ -1,0 +1,5 @@
+{
+  "plugins": {
+    "autoprefixer": {}
+  }
+}

--- a/packages/postcss/test/fixtures/sub2/package.json
+++ b/packages/postcss/test/fixtures/sub2/package.json
@@ -1,0 +1,8 @@
+{
+  "private": true,
+  "postcss": {
+    "plugins": {
+      "autoprefixer": {}
+    }
+  }
+}

--- a/packages/postcss/test/fixtures/sub3/postcss.config.js
+++ b/packages/postcss/test/fixtures/sub3/postcss.config.js
@@ -1,0 +1,5 @@
+const autoprefixer = require('autoprefixer');
+
+module.exports = conf => ({
+	plugins: conf.plugins.concat(autoprefixer)
+});

--- a/packages/postcss/test/fixtures/sub4/.postcssrc.js
+++ b/packages/postcss/test/fixtures/sub4/.postcssrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+	plugins: [
+		require('autoprefixer')
+	]
+};

--- a/packages/postcss/test/fixtures/sub5/.postcssrc
+++ b/packages/postcss/test/fixtures/sub5/.postcssrc
@@ -1,0 +1,8 @@
+{
+  "plugins": [
+    "autoprefixer"
+  ],
+  "options": {
+    "parser": "postcss-scss"
+  }
+}

--- a/packages/postcss/test/index.js
+++ b/packages/postcss/test/index.js
@@ -65,6 +65,29 @@ test('@taskr/postcss (options)', t => {
 	}).start('foo');
 });
 
+test('@taskr/postcss (postcssrc)', t => {
+	t.plan(2);
+	const taskr = new Taskr({
+		plugins,
+		cwd: join(dir, 'sub1'),
+		tasks: {
+			*foo(f) {
+				const tmp = tmpDir('tmp-3');
+				yield f.source(`${dir}/*.css`).postcss().target(tmp);
+
+				const arr = yield f.$.expand(`${tmp}/*.*`);
+				t.equal(arr.length, 1, 'write one file to target');
+
+				const str = yield f.$.read(`${tmp}/foo.css`, 'utf8');
+				t.true(/-webkit-box/.test(str), 'applies `autoprefixer` plugin transform');
+
+				yield f.clear(tmp);
+			}
+		}
+	});
+	taskr.start('foo');
+});
+
 // test('@taskr/postcss (inline)', t => {
 // 	t.plan(2);
 // 	create({

--- a/packages/postcss/test/index.js
+++ b/packages/postcss/test/index.js
@@ -88,6 +88,75 @@ test('@taskr/postcss (postcssrc)', t => {
 	taskr.start('foo');
 });
 
+test('@taskr/postcss (package.json)', t => {
+	t.plan(2);
+	const taskr = new Taskr({
+		plugins,
+		cwd: join(dir, 'sub2'),
+		tasks: {
+			*foo(f) {
+				const tmp = tmpDir('tmp-4');
+				yield f.source(`${dir}/*.css`).postcss().target(tmp);
+
+				const arr = yield f.$.expand(`${tmp}/*.*`);
+				t.equal(arr.length, 1, 'write one file to target');
+
+				const str = yield f.$.read(`${tmp}/foo.css`, 'utf8');
+				t.true(/-webkit-box/.test(str), 'applies `autoprefixer` plugin transform');
+
+				yield f.clear(tmp);
+			}
+		}
+	});
+	taskr.start('foo');
+});
+
+test('@taskr/postcss (postcss.config.js)', t => {
+	t.plan(2);
+	const taskr = new Taskr({
+		plugins,
+		cwd: join(dir, 'sub3'),
+		tasks: {
+			*foo(f) {
+				const tmp = tmpDir('tmp-5');
+				yield f.source(`${dir}/*.css`).postcss().target(tmp);
+
+				const arr = yield f.$.expand(`${tmp}/*.*`);
+				t.equal(arr.length, 1, 'write one file to target');
+
+				const str = yield f.$.read(`${tmp}/foo.css`, 'utf8');
+				t.true(/-webkit-box/.test(str), 'applies `autoprefixer` plugin transform');
+
+				yield f.clear(tmp);
+			}
+		}
+	});
+	taskr.start('foo');
+});
+
+test('@taskr/postcss (.postcssrc.js)', t => {
+	t.plan(2);
+	const taskr = new Taskr({
+		plugins,
+		cwd: join(dir, 'sub4'),
+		tasks: {
+			*foo(f) {
+				const tmp = tmpDir('tmp-6');
+				yield f.source(`${dir}/*.css`).postcss().target(tmp);
+
+				const arr = yield f.$.expand(`${tmp}/*.*`);
+				t.equal(arr.length, 1, 'write one file to target');
+
+				const str = yield f.$.read(`${tmp}/foo.css`, 'utf8');
+				t.true(/-webkit-box/.test(str), 'applies `autoprefixer` plugin transform');
+
+				yield f.clear(tmp);
+			}
+		}
+	});
+	taskr.start('foo');
+});
+
 // test('@taskr/postcss (inline)', t => {
 // 	t.plan(2);
 // 	create({

--- a/packages/postcss/test/index.js
+++ b/packages/postcss/test/index.js
@@ -157,6 +157,31 @@ test('@taskr/postcss (.postcssrc.js)', t => {
 	taskr.start('foo');
 });
 
+test('@taskr/postcss (plugins<Array> + options<String>)', t => {
+	t.plan(4);
+	const taskr = new Taskr({
+		plugins,
+		cwd: join(dir, 'sub5'),
+		tasks: {
+			*foo(f) {
+				const tmp = tmpDir('tmp-7');
+				yield f.source(`${dir}/*.scss`).postcss().target(tmp);
+
+				const arr = yield f.$.expand(`${tmp}/*.*`);
+				t.equal(arr.length, 1, 'write one file to target');
+
+				const str = yield f.$.read(`${tmp}/bar.scss`, 'utf8');
+				t.true(str.indexOf('-ms-flexbox') !== -1, 'applies prefixer to CSS lookalike');
+				t.true(str.indexOf('-webkit-box-flex: val') !== -1, 'applies prefixer to SCSS mixin');
+				t.ok(str, 'retains `.scss` file extension');
+
+				yield f.clear(tmp);
+			}
+		}
+	});
+	taskr.start('foo');
+});
+
 // test('@taskr/postcss (inline)', t => {
 // 	t.plan(2);
 // 	create({


### PR DESCRIPTION
When no `options` are passed, the `@taskr/postcss` plugin will now look for & respect configs found within: ~(arranged by preference):~

- a `.postcssrc` file (JSON-type only)
- the "postcss" key inside `package.json`
- a `postcss.config.js` file (`Object` or `Function` type)
- a `.postcssrc.js` file (`Object` or `Function` type)

As for usage, all options are available:

```js
// send options (current)
yield task.source(...).postcss({
  plugins: [], 
  options: {}
}).target(...);

// run autoload checks (any of above)
yield task.source(...).postcss().target(...);
```

An error will be emitted, forcing the plugin to stop, if the final/parsed `options` is not an Object.

~TODO: Add autoload-config tests.~

Closes #283