### PR TITLE
Allow `import` statements via `esnext`

### DIFF
--- a/packages/esnext/package.json
+++ b/packages/esnext/package.json
@@ -14,7 +14,8 @@
     "url": "https://lukeed.com"
   },
   "dependencies": {
-    "require-like": "^0.1.2"
+    "require-like": "^0.1.2",
+    "rewrite-imports": "^1.0.0"
   },
   "devDependencies": {
     "bluebird": "^3.5.0"

--- a/packages/esnext/readme.md
+++ b/packages/esnext/readme.md
@@ -8,7 +8,7 @@
 $ npm install --save-dev @taskr/esnext
 ```
 
-**That's it!** :tada: You've now enabled `async`/`await` syntax for your `taskfile.js`!
+**That's it!** :tada: You've now enabled `async`/`await` and `import` syntax for your `taskfile.js`!
 
 > **Note:** This will NOT compile your ES6 files into ES5. You must download and setup [`@taskr/babel`](https://npmjs.com/package/@taskr/babel) or [`@taskr/buble`](https://npmjs.com/package/@taskr/buble) for that.
 
@@ -18,6 +18,7 @@ A `taskfile.js` may also include `require()` statements (not shown).
 
 ```js
 // taskfile.js
+import { foo, bar as baz } from './bat';
 
 export default async function (task) {
   await task.source('src/*.js') // etc...

--- a/packages/esnext/test/fixtures/bar.js
+++ b/packages/esnext/test/fixtures/bar.js
@@ -1,0 +1,3 @@
+exports.bar = 'hello';
+
+exports.baz = 'world';

--- a/packages/esnext/test/fixtures/taskfile.js
+++ b/packages/esnext/test/fixtures/taskfile.js
@@ -1,5 +1,6 @@
 const aaa = 42;
-const foo = require('./foo');
+import foo from './foo';
+import { bar as quz, baz as qut } from './bar';
 
 export default async function () {
   await this.source('src/*.js').target('dist');
@@ -7,7 +8,7 @@ export default async function () {
 
 export async function foo () {
   await this.clear('dist');
-  return await this.start('bar', {val: aaa});
+  return await this.start('bar', { val:aaa });
 }
 
 export async function bar(o) {
@@ -15,9 +16,9 @@ export async function bar(o) {
 }
 
 export async function baz(one, two) {
-  return {one, two};
+  return { one, two };
 }
 
 export async function bat (one, two) {
-  return {one, two};
+  return `${quz} ${qut}`;
 }

--- a/packages/esnext/test/index.js
+++ b/packages/esnext/test/index.js
@@ -13,7 +13,7 @@ const hasYield = f => /yield/i.test(f.toString());
 const isGenerator = f => f.constructor.name === 'GeneratorFunction';
 
 test('@taskr/esnext', co(function * (t) {
-	t.plan(25);
+	t.plan(26);
 
 	t.equal(typeof fn, 'function', 'export a function');
 
@@ -42,4 +42,7 @@ test('@taskr/esnext', co(function * (t) {
 
 	const val2 = yield co(out.baz)('foo', 'bar');
 	t.deepEqual(val2, {one: 'foo', two: 'bar'}, 'accepts & handles multiple parameters');
+
+	const val3 = yield co(out.bat)();
+	t.equal(val3, 'hello world', 'handles aliased import partials correctly');
 }));


### PR DESCRIPTION
Wrote & attached a quick RegExp manipulator: [`rewrite-imports`](https://github.com/lukeed/rewrite-imports)

It should cover 90% of use cases right now. AFAIK, it's only incompatible with multi-line import statements; eg:

```js
import {
  foo,
  bar
} from 'baz';
```

I can fix it, just ran out of time for today.