### PR TITLE
Rename clorox to turbocolor

### DIFF
--- a/packages/taskr/lib/fmt.js
+++ b/packages/taskr/lib/fmt.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const c = require('clorox');
+const c = require('turbocolor');
 
 module.exports = {
 	complete: c.blue.bold,

--- a/packages/taskr/lib/utils/logging.js
+++ b/packages/taskr/lib/utils/logging.js
@@ -6,7 +6,7 @@
  * 		- use es2015
  */
 
-const clorox = require('clorox');
+const turbocolor = require('turbocolor');
 const homedir = require('os').homedir;
 const getTime = require('../fn').getTime;
 
@@ -27,7 +27,7 @@ function stamp() {
 	}
 
 	// print the curr time.
-	process.stdout.write(clorox[this.color](getTime()) + ' ');
+	process.stdout.write(turbocolor[this.color](getTime()) + ' ');
 
 	// apply arguments to `console` method
 	console[this.method].apply(console, (this.custom ? [this.custom].concat(args) : args));
@@ -50,7 +50,7 @@ function error() {
 function alert() {
 	if (process.env.VERBOSE) {
 		stamp.apply({
-			custom: clorox.yellow.bold("%s"),
+			custom: turbocolor.yellow.bold("%s"),
 			color: 'yellow',
 			method: 'log'
 		}, arguments);

--- a/packages/taskr/package.json
+++ b/packages/taskr/package.json
@@ -20,7 +20,7 @@
   ],
   "dependencies": {
     "bluebird": "^3.5.0",
-    "clorox": "^1.0.1",
+    "turbocolor": "^1.0.0",
     "glob": "^7.1.2",
     "mk-dirs": "^1.0.0",
     "mri": "^1.1.0",


### PR DESCRIPTION
Signed-off-by: Hiroaki Nakamura <hnakamur@gmail.com>

[clorox - npm](https://www.npmjs.com/package/clorox/v/1.0.0) says "Clorox is now Turbocolor!! - Please upgrade <3 'npm i turbocolor'"