### PR TITLE
fix(taskr): use createRequire to perform relative requires and add missing optional peer dependency @taskr/esnext

### DIFF
--- a/packages/taskr/lib/plugins.js
+++ b/packages/taskr/lib/plugins.js
@@ -4,6 +4,7 @@ const p = require('path');
 const flatten = require('./fn').flatten;
 const isObject = require('./fn').isObject;
 const co = require('bluebird').coroutine;
+const createRequire = require('create-require');
 const $ = require('./utils');
 
 const rgx = /^@(taskr|fly)|(taskr|fly)-/i;
@@ -18,13 +19,8 @@ const join = p.join;
  */
 function req(name, base) {
 	try {
-		try {
-			name = require.resolve(name);
-		} catch (_) {
-			name = join(base, name);
-		} finally {
-			return require(name);
-		}
+		const relativeRequire = createRequire(base)
+		return relativeRequire(name);
 	} catch (e) {
 		$.alert(e.message);
 	}

--- a/packages/taskr/package.json
+++ b/packages/taskr/package.json
@@ -30,6 +30,14 @@
   "devDependencies": {
     "rimraf": "^2.6.1"
   },
+  "peerDependencies": {
+    "@taskr/esnext": "^1.1.0"
+  },
+  "peerDependenciesMeta": {
+    "@taskr/esnext": {
+      "optional": true
+    }
+  },
   "scripts": {
     "test": "tape test/*.js | tap-spec"
   },

--- a/packages/taskr/package.json
+++ b/packages/taskr/package.json
@@ -19,6 +19,7 @@
     "taskr.d.ts"
   ],
   "dependencies": {
+    "create-require": "^1.0.2",
     "bluebird": "^3.5.0",
     "clorox": "^1.0.1",
     "glob": "^7.1.2",


### PR DESCRIPTION
**What's the problem this PR addresses?**

`taskr` makes assumptions about the `node_modules` layout and tries to require files directly from it instead of using `createRequire`, `taskr` also has an optional peer dependency on `@taskr/esnext` that it doesn't declare making it rely heavily on hoisting to place it in an accesible location.

Read https://yarnpkg.com/advanced/rulebook for more in depth information

**How did you fix it?**

- Use `createRequire` to perform the require relative to the `base` https://nodejs.org/api/module.html#module_module_createrequire_filename
- Add `@taskr/esnext` as a optional peer dependency


cc @lukeed @arcanis 